### PR TITLE
Use TemporalMetrics as the datasource consistently.

### DIFF
--- a/dashboards/10000.json
+++ b/dashboards/10000.json
@@ -4,7 +4,7 @@
       {
         "$$hashKey": "object:218",
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": "TemporalMetrics",
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -23,7 +23,7 @@
   "panels": [
     {
       "collapsed": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -817,7 +817,7 @@
     },
     {
       "collapsed": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -936,7 +936,7 @@
     },
     {
       "collapsed": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1053,7 +1053,7 @@
     },
     {
       "collapsed": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "gridPos": {
         "h": 1,
         "w": 24,

--- a/dashboards/canary.json
+++ b/dashboards/canary.json
@@ -3,7 +3,7 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": "TemporalMetrics",
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -23,7 +23,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -123,7 +123,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -217,7 +217,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -319,7 +319,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -407,7 +407,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -496,7 +496,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -585,7 +585,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -674,7 +674,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {

--- a/dashboards/common.json
+++ b/dashboards/common.json
@@ -3,7 +3,7 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": "TemporalMetrics",
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -21,7 +21,7 @@
   "panels": [
     {
       "collapsed": true,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -35,7 +35,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -129,7 +129,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -217,7 +217,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -326,7 +326,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -415,7 +415,7 @@
     },
     {
       "collapsed": true,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -429,7 +429,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -523,7 +523,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -611,7 +611,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -699,7 +699,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -788,7 +788,7 @@
     },
     {
       "collapsed": true,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -802,7 +802,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -896,7 +896,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -984,7 +984,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -1072,7 +1072,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -1161,7 +1161,7 @@
     },
     {
       "collapsed": true,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1175,7 +1175,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -1269,7 +1269,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -1357,7 +1357,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -1445,7 +1445,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {

--- a/dashboards/frontend.json
+++ b/dashboards/frontend.json
@@ -3,7 +3,7 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": "TemporalMetrics",
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -20,7 +20,7 @@
   "panels": [
     {
       "collapsed": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -37,7 +37,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -131,7 +131,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -219,7 +219,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -328,7 +328,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -413,7 +413,7 @@
     },
     {
       "collapsed": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -430,7 +430,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -524,7 +524,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -612,7 +612,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -700,7 +700,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -785,7 +785,7 @@
     },
     {
       "collapsed": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -802,7 +802,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -896,7 +896,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -984,7 +984,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1072,7 +1072,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1157,7 +1157,7 @@
     },
     {
       "collapsed": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1174,7 +1174,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1268,7 +1268,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1356,7 +1356,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1444,7 +1444,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {

--- a/dashboards/history.json
+++ b/dashboards/history.json
@@ -3,7 +3,7 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": "TemporalMetrics",
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -20,7 +20,7 @@
   "panels": [
     {
       "collapsed": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -37,7 +37,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -131,7 +131,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -219,7 +219,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -307,7 +307,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -416,7 +416,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -501,7 +501,7 @@
     },
     {
       "collapsed": true,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -515,7 +515,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -609,7 +609,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -697,7 +697,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -785,7 +785,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -879,7 +879,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -967,7 +967,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -1055,7 +1055,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -1143,7 +1143,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -1263,7 +1263,7 @@
     },
     {
       "collapsed": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1280,7 +1280,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1374,7 +1374,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1462,7 +1462,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1550,7 +1550,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1644,7 +1644,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1732,7 +1732,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1820,7 +1820,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1908,7 +1908,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -2024,7 +2024,7 @@
     },
     {
       "collapsed": true,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -2038,7 +2038,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -2127,7 +2127,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -2215,7 +2215,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -2322,7 +2322,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -2410,7 +2410,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -2505,7 +2505,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -2593,7 +2593,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -2700,7 +2700,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -2808,7 +2808,7 @@
     },
     {
       "collapsed": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -2825,7 +2825,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -2919,7 +2919,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -3019,7 +3019,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -3107,7 +3107,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -3195,7 +3195,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -3283,7 +3283,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -3371,7 +3371,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -3456,7 +3456,7 @@
     },
     {
       "collapsed": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -3473,7 +3473,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -3633,7 +3633,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -3735,7 +3735,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -3823,7 +3823,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -3911,7 +3911,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -3996,7 +3996,7 @@
     },
     {
       "collapsed": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -4013,7 +4013,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -4098,7 +4098,7 @@
     },
     {
       "collapsed": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -4115,7 +4115,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -4203,7 +4203,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -4291,7 +4291,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -4379,7 +4379,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -4473,7 +4473,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -4558,7 +4558,7 @@
     },
     {
       "collapsed": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -4575,7 +4575,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -4669,7 +4669,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -4757,7 +4757,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -4845,7 +4845,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -4930,7 +4930,7 @@
     },
     {
       "collapsed": true,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -4944,7 +4944,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -5038,7 +5038,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {

--- a/dashboards/matching.json
+++ b/dashboards/matching.json
@@ -3,7 +3,7 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": "TemporalMetrics",
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -20,7 +20,7 @@
   "panels": [
     {
       "collapsed": true,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -34,7 +34,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -128,7 +128,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -216,7 +216,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -325,7 +325,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -414,7 +414,7 @@
     },
     {
       "collapsed": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -431,7 +431,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -531,7 +531,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -619,7 +619,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -714,7 +714,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -809,7 +809,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -897,7 +897,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -985,7 +985,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1073,7 +1073,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1161,7 +1161,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1246,7 +1246,7 @@
     },
     {
       "collapsed": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1263,7 +1263,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1357,7 +1357,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1445,7 +1445,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1539,7 +1539,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1624,7 +1624,7 @@
     },
     {
       "collapsed": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1641,7 +1641,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1735,7 +1735,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1823,7 +1823,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1911,7 +1911,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1996,7 +1996,7 @@
     },
     {
       "collapsed": true,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -2010,7 +2010,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -2104,7 +2104,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -2192,7 +2192,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -2280,7 +2280,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {

--- a/dashboards/sdk.json
+++ b/dashboards/sdk.json
@@ -3,7 +3,7 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": "TemporalMetrics",
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -12,6 +12,7 @@
       }
     ]
   },
+  "description": "SDK dashboard for Temporal",
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
@@ -21,7 +22,7 @@
   "panels": [
     {
       "collapsed": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -38,7 +39,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -132,7 +133,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -220,7 +221,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -308,7 +309,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -393,7 +394,7 @@
     },
     {
       "collapsed": true,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -407,7 +408,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -514,7 +515,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -602,7 +603,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -691,7 +692,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -781,7 +782,7 @@
     },
     {
       "collapsed": true,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -795,7 +796,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -883,7 +884,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -971,7 +972,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -1059,7 +1060,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -1147,7 +1148,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -1235,7 +1236,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -1323,7 +1324,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -1411,7 +1412,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -1499,7 +1500,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -1587,7 +1588,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -1675,7 +1676,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -1764,7 +1765,7 @@
     },
     {
       "collapsed": true,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1778,7 +1779,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -1866,7 +1867,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -1954,7 +1955,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -2042,7 +2043,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -2130,7 +2131,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -2219,7 +2220,7 @@
     },
     {
       "collapsed": true,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -2233,7 +2234,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -2321,7 +2322,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -2409,7 +2410,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -2498,7 +2499,7 @@
     },
     {
       "collapsed": true,
-      "datasource": null,
+      "datasource": "TemporalMetrics",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -2512,7 +2513,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -2600,7 +2601,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -2688,7 +2689,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -2776,7 +2777,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "TemporalMetrics",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {


### PR DESCRIPTION
This reduces the work required to import and use the dashboards as
TemporalMetrics only needs to be defined once.

Currently people must either edit the JSON before importing or adjust
every graph to use a relevant datasource.