### PR TITLE
Fix minor typo in metric label

### DIFF
--- a/dashboards/history.json
+++ b/dashboards/history.json
@@ -350,7 +350,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum(rate(service_errors_execution_already_started{type=\"hisotry\"}[5m]))",
+          "expr": "sum(rate(service_errors_execution_already_started{type=\"history\"}[5m]))",
           "hide": false,
           "interval": "",
           "legendFormat": "Execution Already Started",


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
A metric label in one of the PromQL queries in the `history` dashboard.

## Why?
Because of a minor typo.

## Checklist

1. Closes N/A

2. How was this tested: Re-import of `history` the dashboard

3. Any docs updates needed? N/A
