### PR TITLE
Updating default timescale from hardcoded date to past 30 mins.

### DIFF
--- a/dashboards/temporal.json
+++ b/dashboards/temporal.json
@@ -3303,8 +3303,8 @@
     ]
   },
   "time": {
-    "from": "2020-07-06T20:26:29.333Z",
-    "to": "2020-07-06T20:44:39.936Z"
+    "from": "now-30m",
+    "to": "now"
   },
   "timepicker": {
     "refresh_intervals": [


### PR DESCRIPTION
## What was changed
The default timescale in `temporal.json` was for a specific time period in summer of 2020. I updated it to just be for the last 30 minutes.

## Why?
The way it was could confuse other people new to Grafana. Took me a minute to realize the reason that none of my Temporal data was loading in through Morpheus was because of the wrong time scale. This make it easier to use out of the box. Something something DevEx. :)

## Checklist
1. Closes #16

2. How was this tested:
I tested this by running this JSON on my own Temporal cluster and verifying that the default timescale for the dashboard created by the `temporal.json` model is `Last 30 minutes`.

3. Any docs updates needed?
I don't believe so.
