### PR TITLE
(trivial) Make sdk-general.json dashboard title consistent with server-general.json

### DIFF
--- a/sdk/sdk-general.json
+++ b/sdk/sdk-general.json
@@ -2934,7 +2934,7 @@
     ]
   },
   "timezone": "",
-  "title": "SDK Metrics",
+  "title": "Temporal SDK Metrics",
   "variables": {
     "list": []
   },


### PR DESCRIPTION
I noticed that the dashboard title of sdk-general.json is "SDK Metrics", where the dashboard title of sever-general.json is "Temporal Server Metrics". For consistency, would you consider changing the sdk-general.json dashboard title to "Temporal SDK Metrics"?

## What was changed
sdk-general.json dashboard title changed from "SDK Metrics" to "Temporal SDK Metrics".

## Why?
To be consistent with server-general.json's title. I went looking for the SDK dashboard after deploying it and couldn't find it searching for "temporal".

## Checklist
1. How was this tested:
    1. Deploy this commit or modify the Grafana dashboard JSON model under settings if already deployed.
    1. Observe title change.

2. Any docs updates needed?
I don't think so.