### PR TITLE
Adding actions metrics for difference OSS versions

### DIFF
--- a/server/server-general.json
+++ b/server/server-general.json
@@ -35,6 +35,60 @@
         "x": 0,
         "y": 0
       },
+      "id": 70,
+      "panels": [],
+      "title": "Temporal Actions",
+      "type": "row"
+    },
+    {
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 68,
+      "options": {
+        "alertThreshold": true
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "editorMode": "code",
+          "expr": "sum(rate(service_requests{service_name=\"frontend\",operation=~\"QueryWorkflow|RecordActivityTaskHeartbeat|RecordActivityTaskHeartbeatById|ResetWorkflowExecution|StartWorkflowExecution|SignalWorkflowExecution|SignalWithStartWorkflowExecution|CreateSchedule|UpdateSchedule|DeleteSchedule|PatchSchedule|UpdateWorkflowExecution|RespondActivityTaskCompleted|RespondActivityTaskFailed\"}[1m])) + (sum (rate(start_timer_command{service_name=\"history\"}[1m])) OR on() vector(0)) + (sum (rate(signal_external_workflow_command{service_name=\"history\"}[1m])) OR on() vector(0)) + (sum (rate(record_marker_command{service_name=\"history\"}[1m])) + sum (rate(continue_as_new_command{service_name=\"history\"}[1m]))OR on() vector(0)) + (sum (rate(signal_external_workflow_command{service_name=\"history\"}[1m]))OR on() vector(0)) + 2 * (sum (rate(child_workflow_command{service_name=\"history\"}[1m]))OR on() vector(0)) + (sum (rate(upsert_workflow_search_attributes_command{service_name=\"history\"}[1m]))OR on() vector(0)) + (sum (rate(modify_workflow_properties_command{service_name=\"history\"}[1m]))OR on() vector(0))",
+          "legendFormat": "OSS v1.16 And Older",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": null,
+          "editorMode": "code",
+          "expr": "sum(rate(action{service_name=\"frontend\"}[1m]))",
+          "hide": false,
+          "legendFormat": "OSS v1.17 And Newer",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Actions",
+      "type": "graph"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
       "id": 11,
       "panels": [],
       "title": "Temporal",


### PR DESCRIPTION
## What was changed
Added a new dashboard panel for showing action metrics for v1.17+ and older versions.

## Why?
Temporal open source server introduced "action" metrics in v1.17 (released Jun 2022) to help self-hosted users to estimate their expected cloud cost (only actions, no storage).
Prior to server v1.17, we could still count individual metrics to estimate action cost. 

## Checklist

1. Closes

2. How was this tested:
Ran locally
<img width="1004" alt="Screenshot 2024-04-04 at 2 26 40 AM" src="https://github.com/temporalio/dashboards/assets/4952535/9da00fe0-1bcb-4557-8e05-cf7df3af1cbb">


3. Any docs updates needed?
