### PR TITLE
minor fix for namespace access

### DIFF
--- a/sdk/sdk-general.json
+++ b/sdk/sdk-general.json
@@ -2636,7 +2636,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum by (namespace) (rate(temporal_sticky_cache_miss{namespace=~\"Namespace\"}[5m]))",
+              "expr": "sum by (namespace) (rate(temporal_sticky_cache_miss{namespace=~\"$Namespace\"}[5m]))",
               "interval": "",
               "legendFormat": "{{ namespace  }}",
               "refId": "A"
@@ -2724,7 +2724,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum by (namespace) (rate(temporal_sticky_cache_total_forced_eviction{namespace=~\"Namespace\"}[5m]))",
+              "expr": "sum by (namespace) (rate(temporal_sticky_cache_total_forced_eviction{namespace=~\"$Namespace\"}[5m]))",
               "interval": "",
               "legendFormat": "{{ namespace  }}",
               "refId": "A"


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
For two graphs Namespace refered as string but should as variable. $ sign has been missed.
## Why?
<!-- Tell your future self why have you made these changes -->
To fix Sticky cache graphs
## Checklist

1. How was this tested:

Local grafana.

3. Any docs updates needed?

No.
