### PR TITLE
fix namespace access

### DIFF
--- a/sdk/sdk-general.json
+++ b/sdk/sdk-general.json
@@ -2636,7 +2636,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum by (namespace) (rate(temporal_sticky_cache_miss{namespace=~\"Namespace\"}[5m]))",
+              "expr": "sum by (namespace) (rate(temporal_sticky_cache_miss{namespace=~\"$Namespace\"}[5m]))",
               "interval": "",
               "legendFormat": "{{ namespace  }}",
               "refId": "A"
@@ -2724,7 +2724,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum by (namespace) (rate(temporal_sticky_cache_total_forced_eviction{namespace=~\"Namespace\"}[5m]))",
+              "expr": "sum by (namespace) (rate(temporal_sticky_cache_total_forced_eviction{namespace=~\"$Namespace\"}[5m]))",
               "interval": "",
               "legendFormat": "{{ namespace  }}",
               "refId": "A"


### PR DESCRIPTION
## What was changed

For two graphs Namespace referred as string but should as variable. $ sign has been missed.

## Why?

To fix Sticky cache graphs

## Checklist
<!--- add/delete as needed --->

1. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Local grafana test.

3. Any docs updates needed?

No.
