### PR TITLE
Use sum for state transitions metric instead of count

### DIFF
--- a/server/server-general.json
+++ b/server/server-general.json
@@ -1464,7 +1464,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(rate(state_transition_count_count[1m]))",
+          "expr": "sum(rate(state_transition_count_sum[1m]))",
           "hide": false,
           "interval": "",
           "legendFormat": "state transition",


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Updated state_transitions_count graph

## Why?
<!-- Tell your future self why have you made these changes -->
The metric should be a sum instead of count.

## Checklist
<!--- add/delete as needed --->

1. Closes #56 

2. How was this tested: Grafana Query Explorer
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
