### PR TITLE
fix: reference to data source

### DIFF
--- a/cloud/temporal_cloud.json
+++ b/cloud/temporal_cloud.json
@@ -3295,7 +3295,7 @@
         "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "${DS_EXTERNAL_METRICS}"
+          "uid": "${datasource}"
         },
         "definition": "label_values(temporal_namespace)",
         "includeAll": false,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

- reference to the data source using type instead of name

## Why?

Importing this dashboard  manually works fine. 

but I have been deploying these dashboards to my grafana using terraform and encountered this error 
<img width="637" height="362" alt="image" src="https://github.com/user-attachments/assets/fc853888-eb2a-425d-a7cd-8ce8869a5b64" />




## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
- tried importing manually
- tried importing with terraform

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
