### PR TITLE
Include queue name in sdk-otel dashboard

### DIFF
--- a/sdk/temporal-go-sdk-otel.json
+++ b/sdk/temporal-go-sdk-otel.json
@@ -2798,7 +2798,7 @@
           "editorMode": "code",
           "expr": "temporal_worker_task_slots_available{namespace=~\"$namespace\"}",
           "intervalFactor": 2,
-          "legendFormat": "namespace: {{ namespace }}; worker_type:{{worker_type}}",
+          "legendFormat": "namespace: {{ namespace }}; worker_type:{{worker_type}}; task_queue:{{task_queue}}",
           "range": true,
           "refId": "A"
         }
@@ -3004,7 +3004,7 @@
           "editorMode": "code",
           "expr": "temporal_worker_task_slots_used{namespace=~\"$namespace\"}",
           "intervalFactor": 2,
-          "legendFormat": "namespace: {{ namespace }}; worker_type:{{worker_type}}",
+          "legendFormat": "namespace: {{ namespace }}; worker_type:{{worker_type}}; task_queue:{{task_queue}}",
           "range": true,
           "refId": "A"
         }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
The temporal-go-sdk-otel dashboard was changed to show task_queue in both "slots available" and "slots used".

## Why?
Slot metrics are useful as an indication of what part of your system needs scaling. Currently the metrics were not identifyable to a specific queue, giving no indication of what needed scaling.

## Checklist

1. How was this tested:
This change was also made on my local copy of this dashboard.

2. Any docs updates needed?
Not afaik
